### PR TITLE
feat: add hideTitle deprecated option

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -87,6 +87,14 @@
           "title": "Labels unter Karte anzeigen",
           "type": "boolean",
           "default": false
+        },
+        "hideTitle": {
+          "type": "boolean",
+          "default": false,
+          "Q:deprecated": true,
+          "Q:options": {
+            "hideInEditor": true
+          }
         }
       },
       "required": ["baseLayer", "initialZoomLevel", "minimap", "labelsBelowMap"]
@@ -186,6 +194,14 @@
       "type": "object",
       "Q:type": "json",
       "title": "GeoJSON Feature",
+      "Q:options": {
+        "availabilityChecks": [
+          {
+            "type": "UserHasRole",
+            "role": "expert-map"
+          }
+        ]
+      },
       "properties": {
         "type": {
           "type": "string",

--- a/views/html-js.html
+++ b/views/html-js.html
@@ -1,5 +1,7 @@
 <div class="s-q-item">
-  <h3 class="s-q-item__title">{{title}}</h3>
+  {{#if options.hideTitle !== true }}
+    <h3 class="s-q-item__title">{{title}}</h3>
+  {{/if}}
   <div class="q-map-container" id="{{ mapContainerId }}"></div>
   <div class="s-q-item__footer">
     {{#if options.labelsBelowMap === true}}


### PR DESCRIPTION
adds hideTitle as a deprecated option hidden in editor. This makes to old migrated maps work as expected.