### PR TITLE
feat: use sophie-font for labels and text

### DIFF
--- a/slippyMap/resources/LeafletMap.js
+++ b/slippyMap/resources/LeafletMap.js
@@ -175,6 +175,8 @@ export default class LeafletMap {
           this.addTileLayer(layer.url.labels, labelsLayerConfig, layer.containerClass);
         }
       }
+      // set the sophie font class to the attribution control to not repeat it in css
+      this.map.getContainer().querySelector('.leaflet-control-attribution').classList.add('s-font-note-s');
     });
     if (layer.minimapLayerUrl) {
       this.tileLayerMiniMap =

--- a/slippyMap/resources/markerTypes.js
+++ b/slippyMap/resources/markerTypes.js
@@ -9,7 +9,7 @@ export const markerTypes = {
         .divIcon({
           className: 'q-map-marker s-color-gray-1',
           iconSize: [8, 8],
-          html: `<div class="q-map-marker__label s-color-gray-8 q-map-marker__label--${marker.labelPosition ? marker.labelPosition : 'top'} q-map-marker__label--heavy">${marker.label || ''}</div>`
+          html: `<div class="s-font-note s-font-note--strong q-map-marker__label q-map-marker__label--${marker.labelPosition ? marker.labelPosition : 'top'} q-map-marker__label--heavy">${marker.label || ''}</div>`
         });
     }
   },
@@ -22,7 +22,7 @@ export const markerTypes = {
         .divIcon({
           className: 'q-map-marker s-color-gray-1',
           iconSize: [8, 8],
-          html: `<div class="q-map-marker__label s-color-gray-8 q-map-marker__label--${marker.labelPosition ? marker.labelPosition : 'top'} q-map-marker__label--light">${marker.label || ''}</div>`
+          html: `<div class="s-font-note s-font-note--strong q-map-marker__label q-map-marker__label--${marker.labelPosition ? marker.labelPosition : 'top'} q-map-marker__label--light">${marker.label || ''}</div>`
         });
     }
   },
@@ -46,7 +46,7 @@ export const markerTypes = {
         .divIcon({
           className: 'q-map-marker q-map-marker--without-point',
           iconSize: [0, 0],
-          html: `<div class="q-map-marker__label s-color-gray-6 q-map-marker__label--without-point">${marker.label || ''}</div>`
+          html: `<div class="s-font-note s-font-note--strong s-font-note--light q-map-marker__label q-map-marker__label--without-point">${marker.label || ''}</div>`
         });
     }
   },
@@ -58,7 +58,7 @@ export const markerTypes = {
         .divIcon({
           className: 'q-map-marker s-color-gray-1',
           iconSize: [8, 8],
-          html: `<div class="q-map-marker__label s-color-gray-8 q-map-marker__label--${marker.labelPosition ? marker.labelPosition : 'top'} q-map-marker__label--event">${marker.label || ''}</div>`
+          html: `<div class="s-font-note s-font-note--strong q-map-marker__label q-map-marker__label--${marker.labelPosition ? marker.labelPosition : 'top'} q-map-marker__label--event">${marker.label || ''}</div>`
         });
     }
   }

--- a/styles/default.scss
+++ b/styles/default.scss
@@ -47,7 +47,6 @@
 }
 
 .q-map-marker__label {
-  line-height: 1.1;
   position: absolute;
   white-space: nowrap;
   text-align: center;
@@ -56,23 +55,16 @@
 
   left: 4px;
   transform: translateX(-50%);
-
-  .emoji {
-    font-weight: normal;
-    padding: 0 2px;
-  }
+  
+  line-height: 1.1;
 }
 
 .q-map-marker__label--top {
-  bottom: 12px;
+  bottom: 1.1em;
 }
 
 .q-map-marker__label--bottom {
-  top: 12px;
-}
-
-.q-map-marker__label--light {
-  font-size: 12px;
+  top: 1.1em;
 }
 
 .q-map-marker__label--event {
@@ -86,7 +78,7 @@
       color: black;
       text-align: center;
       position: relative;
-      top: -4px;
+      top: -0.1em;
     }
 
   }
@@ -101,13 +93,12 @@
       color: black;
       text-align: center;
       position: relative;
-      top: -3px;
+      top: -0.2em;
     }
   }
 }
 
 .q-map-marker__label--without-point {
-  @extend .q-map-marker__label--light;
   left: 0;
 
   &.q-map-marker__label--top {

--- a/styles/default.scss
+++ b/styles/default.scss
@@ -14,22 +14,19 @@
 .leaflet-bar {
   box-shadow: none;
   border-radius: 0;
-  border: 1px solid #8E8E8E;
+  border: 1px solid #92929e;
 }
 .leaflet-bar a:first-child, .leaflet-bar a:last-child {
   border-radius: 0;
 }
 
-.leaflet-container {
-  font-family: Roboto, Arial, sans-serif;
-}
 // end
 
 // overwrite some styles from leaflet Control.MiniMap
 .leaflet-control-minimap {
   border-radius: 0;
   box-shadow: none;
-  border: 1px solid #8E8E8E;
+  border: 1px solid #92929e;
 }
 // end
 
@@ -50,10 +47,7 @@
 }
 
 .q-map-marker__label {
-  font-family: Roboto, Arial, sans-serif;
-  font-size: 14px;
   line-height: 1.1;
-  font-weight: bold;
   position: absolute;
   white-space: nowrap;
   text-align: center;
@@ -164,7 +158,7 @@
   height: 35px;
   font-size: 10px;
   text-transform: uppercase;
-  border: 1px solid #8E8E8E;
+  border: 1px solid #92929e;
   background: white;
   padding: 5px 9px;
   svg {

--- a/views/HtmlJs.html
+++ b/views/HtmlJs.html
@@ -11,7 +11,7 @@
       {{/each}}
     </div>
   {{/if}}
-  <div class="q-map-container" id="{{ mapContainerId }}" style="height: 250px;"></div>
+  <div class="q-map-container s-font-sans" id="{{ mapContainerId }}" style="height: 250px;"></div>
   <div class="s-q-item__footer">
     {{#if options.labelsBelowMap === true}}
       <div class="q-map-footer__marker-labels">


### PR DESCRIPTION
This uses sophie-font for the labels and replaces the ui gray (for some borders) with one from the new styles.

Would make sense to invest some time to use a sophie-color for these borders, but it's not too simple to do in a clean way. So i leave it for another time.