### PR TITLE
Feat fix world wrap

### DIFF
--- a/routes/fixtures/data.js
+++ b/routes/fixtures/data.js
@@ -18,7 +18,8 @@ const fixtureData = [
   require(`${fixtureDataDirectory}/baseLayerTerrain.json`),
   require(`${fixtureDataDirectory}/baseLayerAerial.json`),
   require(`${fixtureDataDirectory}/showAcronym.json`),
-  require(`${fixtureDataDirectory}/dontShowAcronym.json`)
+  require(`${fixtureDataDirectory}/dontShowAcronym.json`),
+  require(`${fixtureDataDirectory}/antimeridian.json`)
 ];
 
 module.exports = {

--- a/slippyMap/resources/LeafletMap.js
+++ b/slippyMap/resources/LeafletMap.js
@@ -167,8 +167,8 @@ export default class LeafletMap {
       throw new Error("no tile layer url given");
     }
     // do not copy the world, see http://leafletjs.com/reference-1.3.0.html#gridlayer-nowrap
-    config.noWrap = true;
-    config.bounds = [[90, -180], [-90, 180]];
+    //config.noWrap = true;
+    //config.bounds = [[90, -180], [-90, 180]];
     this.baseLayer = Leaflet.tileLayer(url, config).addTo(this.map);
     this.map.getContainer().classList.add(containerClass);
   }

--- a/slippyMap/resources/LeafletMap.js
+++ b/slippyMap/resources/LeafletMap.js
@@ -166,9 +166,6 @@ export default class LeafletMap {
     if (!url) {
       throw new Error("no tile layer url given");
     }
-    // do not copy the world, see http://leafletjs.com/reference-1.3.0.html#gridlayer-nowrap
-    //config.noWrap = true;
-    //config.bounds = [[90, -180], [-90, 180]];
     this.baseLayer = Leaflet.tileLayer(url, config).addTo(this.map);
     this.map.getContainer().classList.add(containerClass);
   }

--- a/slippyMap/resources/geoJsonOptions.js
+++ b/slippyMap/resources/geoJsonOptions.js
@@ -18,5 +18,10 @@ export default {
   },
   style: feature => {
     return feature.properties;
+  },
+  coordsToLatLng: coords => {
+    const lng = Leaflet.Util.wrapNum(coords[0], [0, 360], true);
+    const lat = coords[1];
+    return Leaflet.latlng(lat, lng);
   }
 };

--- a/slippyMap/resources/geoJsonOptions.js
+++ b/slippyMap/resources/geoJsonOptions.js
@@ -22,6 +22,6 @@ export default {
   coordsToLatLng: coords => {
     const lng = Leaflet.Util.wrapNum(coords[0], [0, 360], true);
     const lat = coords[1];
-    return Leaflet.latlng(lat, lng);
+    return Leaflet.latLng(lat, lng);
   }
 };

--- a/slippyMap/resources/geoJsonOptions.js
+++ b/slippyMap/resources/geoJsonOptions.js
@@ -20,8 +20,14 @@ export default {
     return feature.properties;
   },
   coordsToLatLng: coords => {
-    const lng = Leaflet.Util.wrapNum(coords[0], [0, 360], true);
     const lat = coords[1];
+    let lng = coords[0];
+    const pacificBounds = Leaflet.latLngBounds([[-180, -90], [-125, 90]]);
+
+    if (lng < 0 && pacificBounds.contains(coords)) {
+      lng = Leaflet.Util.wrapNum(lng, [0, 360], true);
+    }
+
     return Leaflet.latLng(lat, lng);
   }
 };

--- a/slippyMap/resources/geoJsonOptions.js
+++ b/slippyMap/resources/geoJsonOptions.js
@@ -26,7 +26,7 @@ export default {
 
     // If a point has a negative longitude value and is within the pacific area (pacificBounds) it is projected to a positive value.
     // This allows to show features left and right of the antimeridian line to be shown next to each other.
-    // See the animeridian fixture data for an example and this awesome blog post explaining the problem in depth:
+    // See the antimeridian fixture data for an example and this awesome blog post explaining the problem in depth:
     // https://macwright.org/2016/09/26/the-180th-meridian.html
     if (lng < 0 && pacificBounds.contains(coords)) {
       lng = Leaflet.Util.wrapNum(lng, [0, 360], true);

--- a/slippyMap/resources/geoJsonOptions.js
+++ b/slippyMap/resources/geoJsonOptions.js
@@ -24,6 +24,10 @@ export default {
     let lng = coords[0];
     const pacificBounds = Leaflet.latLngBounds([[-180, -90], [-125, 90]]);
 
+    // If a point has a negative longitude value and is within the pacific area (pacificBounds) it is projected to a positive value.
+    // This allows to show features left and right of the antimeridian line to be shown next to each other.
+    // See the animeridian fixture data for an example and this awesome blog post explaining the problem in depth:
+    // https://macwright.org/2016/09/26/the-180th-meridian.html
     if (lng < 0 && pacificBounds.contains(coords)) {
       lng = Leaflet.Util.wrapNum(lng, [0, 360], true);
     }

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -45,7 +45,7 @@ async function buildScripts() {
     .bundle("q-map/map.js", {
       normalize: true,
       runtime: false,
-      minify: false,
+      minify: true,
       mangle: false
     })
     .then(bundle => {

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -200,6 +200,10 @@ function buildFixtures() {
     "resources/fixtures/data/dontShowAcronym.json",
     JSON.stringify(createFixtureData.dontShowAcronym())
   );
+  fs.writeFileSync(
+    "resources/fixtures/data/antimeridian.json",
+    JSON.stringify(createFixtureData.antimeridian())
+  );
 }
 
 Promise.all([buildScripts(), buildStyles(), buildFixtures()])

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -45,7 +45,7 @@ async function buildScripts() {
     .bundle("q-map/map.js", {
       normalize: true,
       runtime: false,
-      minify: true,
+      minify: false,
       mangle: false
     })
     .then(bundle => {

--- a/tasks/createFixtureData.js
+++ b/tasks/createFixtureData.js
@@ -262,6 +262,27 @@ function dontShowAcronym() {
   return item;
 }
 
+function antimeridian() {
+  const item = {
+    title:
+      "FIXTURE: show pacific view if one of the features is within the pacific area",
+    subtitle: "subtitle",
+    sources: [],
+    notes: "",
+    acronym: "abc",
+    geojsonList: [points.honoluluHeavyTop, points.tokioHeavyTop],
+    options: {
+      baseLayer: "streets",
+      initialZoomLevel: -1,
+      minimapInitialZoomOffset: 0,
+      minimap: true,
+      labelsBelowMap: false,
+      showLegend: true
+    }
+  };
+  return item;
+}
+
 module.exports = {
   mapPoint: createMapPoint,
   mapFeature: createMapFeature,
@@ -278,5 +299,6 @@ module.exports = {
   mapLayerTerrain: createMapLayerTerrain,
   mapLayerAerial: createMapLayerAerial,
   showAcronym: showAcronym,
-  dontShowAcronym: dontShowAcronym
+  dontShowAcronym: dontShowAcronym,
+  antimeridian: antimeridian
 };

--- a/tasks/features.js
+++ b/tasks/features.js
@@ -23,6 +23,30 @@ const points = {
       labelPosition: "bottom"
     }
   },
+  honoluluHeavyTop: {
+    type: "Feature",
+    geometry: {
+      type: "Point",
+      coordinates: [-157.8556764, 21.304547]
+    },
+    properties: {
+      label: "Honolulu",
+      type: "pointHeavyLabel",
+      labelPosition: "top"
+    }
+  },
+  tokioHeavyTop: {
+    type: "Feature",
+    geometry: {
+      type: "Point",
+      coordinates: [139.4049033, 34.6968642]
+    },
+    properties: {
+      label: "Tokio",
+      type: "pointHeavyLabel",
+      labelPosition: "top"
+    }
+  },
   tiranaLightTop: {
     type: "Feature",
     geometry: {


### PR DESCRIPTION
- This PR removes the fix for repeating the world
- Adds a workaround for features which are right of the antimeridian line. Shows a "pacific" view if there are features within the pacific area
- Adds fixture data for this case
- This branch is deployed on https://q.st-test.nzz.ch/item/map-16
