### PR TITLE
Feat minimap design

### DIFF
--- a/slippyMap/resources/LeafletMap.js
+++ b/slippyMap/resources/LeafletMap.js
@@ -247,7 +247,7 @@ export default class LeafletMap {
           aimingRectOptions: {
             color: "#000000",
             fillOpacity: 0,
-            weight: 0.5,
+            weight: 1,
             interactive: false
           },
           shadowRectOptions: {

--- a/slippyMap/resources/LeafletMap.js
+++ b/slippyMap/resources/LeafletMap.js
@@ -245,8 +245,9 @@ export default class LeafletMap {
           toggleDisplay: false,
           zoomLevelFixed: this.minimapZoomLevelFixed,
           aimingRectOptions: {
-            color: "#d28b00",
-            weight: 1,
+            color: "#000000",
+            fillOpacity: 0,
+            weight: 0.5,
             interactive: false
           },
           shadowRectOptions: {

--- a/styles_src/default.scss
+++ b/styles_src/default.scss
@@ -30,7 +30,7 @@
 .leaflet-control-minimap {
   border-radius: 0;
   box-shadow: none;
-  border: 1px solid #92929e;
+  border: 1px solid #000000;
 }
 // end
 

--- a/styles_src/default.scss
+++ b/styles_src/default.scss
@@ -32,6 +32,12 @@
   box-shadow: none;
   border: 1px solid #92929e;
 }
+
+.leaflet-overlay-pane svg g:first-child {
+  fill: black !important;
+  stroke: black !important;
+  stroke-width: 0.5 !important;
+}
 // end
 
 .leaflet-control-minimap-toggle-display {

--- a/styles_src/default.scss
+++ b/styles_src/default.scss
@@ -34,7 +34,7 @@
 }
 
 .leaflet-overlay-pane svg g path {
-  fill: black !important;
+  fill: transparent !important;
   stroke: black !important;
   stroke-width: 0.5 !important;
 }

--- a/styles_src/default.scss
+++ b/styles_src/default.scss
@@ -33,7 +33,7 @@
   border: 1px solid #92929e;
 }
 
-.leaflet-overlay-pane svg g:first-child {
+.leaflet-overlay-pane svg g path {
   fill: black !important;
   stroke: black !important;
   stroke-width: 0.5 !important;

--- a/styles_src/default.scss
+++ b/styles_src/default.scss
@@ -32,12 +32,6 @@
   box-shadow: none;
   border: 1px solid #92929e;
 }
-
-.leaflet-overlay-pane svg g path {
-  fill: transparent !important;
-  stroke: black !important;
-  stroke-width: 0.5 !important;
-}
 // end
 
 .leaflet-control-minimap-toggle-display {


### PR DESCRIPTION
- This PR changes the style of the minimap outer and inner rectangle to have a black border like we have in print

<img width="315" alt="bildschirmfoto 2018-07-12 um 14 20 26" src="https://user-images.githubusercontent.com/1810384/42632844-d566ac6e-85de-11e8-9343-06ab3220568e.png">

- Fixes https://3.basecamp.com/3500782/buckets/1333482/todos/1172164818#__recording_1174199680